### PR TITLE
Updated Urls to Django 2.x

### DIFF
--- a/banana_py/templatetags/banana_tags.py
+++ b/banana_py/templatetags/banana_tags.py
@@ -4,6 +4,7 @@ from banana_py import Bananas_OAuth
 
 register = template.Library()
 
-@register.simple_tag
+
+@register.assignment_tag
 def banana_auth_url(link_text):
     return u'<a href="%s">%s</a>' % (Bananas_OAuth().authorize_url(), link_text)

--- a/banana_py/urls.py
+++ b/banana_py/urls.py
@@ -2,6 +2,6 @@ from django.urls import path
 from banana_py.views import BananasCompleteView
 
 urlpatterns = [
-    path('bananas/ripe/$', BananasCompleteView.as_view(), name='bananas_ripe'),
+    path('bananas/ripe/', BananasCompleteView.as_view(), name='bananas_ripe'),
 
 ]

--- a/banana_py/urls.py
+++ b/banana_py/urls.py
@@ -1,6 +1,7 @@
-from django.conf.urls.defaults import patterns, url
+from django.urls import path
 from banana_py.views import BananasCompleteView
 
-urlpatterns = patterns('',
-    url(r'^bananas/ripe/$', BananasCompleteView.as_view(), name='bananas_ripe'),
-)
+urlpatterns = [
+    path('bananas/ripe/$', BananasCompleteView.as_view(), name='bananas_ripe'),
+
+]


### PR DESCRIPTION
While working with this library I was unable to effectively use this library because django.conf.urls.default has been removed. 

in this fork, I changed the url pattern to match the latest django version url pattern